### PR TITLE
fix(ci): pass P6_A_GH_TOKEN to cdk-upgrade

### DIFF
--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -11,3 +11,5 @@ jobs:
     steps:
       - name: Upgrade Deps
         uses: p6m7g8-actions/cdk-upgrade@main
+        with:
+          gh_token: ${{ secrets.P6_A_GH_TOKEN }}


### PR DESCRIPTION
## Summary
- pass `gh_token` to `p6m7g8-actions/cdk-upgrade@main`
- use `secrets.P6_A_GH_TOKEN` so upgrade PR creation uses automation token path

git -C "/Users/pgollucci/.p6/p6m7g8/p6-template-cdk-eslint-pnpm-ts-flatfile" checkout main