### PR TITLE
ci: pass P6_A_GH_TOKEN to upgrade action

### DIFF
--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -11,3 +11,5 @@ jobs:
     steps:
       - name: Upgrade Deps
         uses: p6m7g8-actions/cdk-upgrade@main
+        with:
+          gh_token: ${{ secrets.P6_A_GH_TOKEN }}


### PR DESCRIPTION
Pass `P6_A_GH_TOKEN` to `p6m7g8-actions/cdk-upgrade@main` so the automation re-label step can trigger auto-approve without manual intervention.